### PR TITLE
Use JPN instead of JAP

### DIFF
--- a/source/main.c
+++ b/source/main.c
@@ -241,7 +241,7 @@ int main()
 
 	bool done = false;
 
-	printf("Press a button according to your region : (A)EUR, (X)USA, (Y)JAP\n");
+	printf("Press a button according to your region : (A)EUR, (X)USA, (Y)JPN\n");
 	// Main loop
 	while (aptMainLoop())
 	{


### PR DESCRIPTION
Since "Jap" is a racial slur, the instruction shown before installation is changed to avoid it just in case. Reddit has shown there are indeed people who are offended by it. Internal references are kept for stability.

- https://www.reddit.com/r/3dshacks/comments/66rn25/doodlebomb_megathread_eur_usa_jap/dglw20s/
- https://en.wikipedia.org/wiki/Jap